### PR TITLE
Add APIs for querying overall and individual item status

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Search                     | Detail Page with resistor     | Mobile view
 
 ## API
 
-Next to a web-UI, this provides as well a search API with JSON response
+Next to a web-UI, this provides as well a search, status, and item information API with JSON response
 to be integrated in other apps, e.g. slack
 
 ### Sample query

--- a/stuff/status-handler.go
+++ b/stuff/status-handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,6 +12,9 @@ import (
 
 const (
 	kStatusPage = "/status"
+	kApiStatus = "/api/status"
+	kApiStatusDefaultOffset = 0
+	kApiStatusDefaultLimit = 100
 )
 
 type StatusHandler struct {
@@ -26,16 +30,27 @@ func AddStatusHandler(store StuffStore, template *TemplateRenderer, imgPath stri
 		imgPath:  imgPath,
 	}
 	http.Handle(kStatusPage, handler)
+	http.Handle(kApiStatus, handler)
 }
 
 type StatusItem struct {
-	Number     int
-	Status     string
-	Separator  int
-	HasPicture bool
+	Number     int    `json:"number"`
+	Status     string `json:"status"`
+	Separator  int    `json:"separator,omitempty"`
+	HasPicture bool   `json:"haspicture"`
 }
 type StatusPage struct {
 	Items []StatusItem
+}
+
+type JsonStatus struct {
+	StatusItem
+}
+type JsonApiStatusResult struct {
+	Directlink string  `json:"link"`
+	Offset int         `json:"offset"`
+	Limit int          `json:"limit"`
+	Items []JsonStatus `json:"status"`
 }
 
 func fillStatusItem(store StuffStore, imageDir string, id int, item *StatusItem) {
@@ -86,30 +101,89 @@ func fillStatusItem(store StuffStore, imageDir string, id int, item *StatusItem)
 }
 
 func (h *StatusHandler) ServeHTTP(out http.ResponseWriter, req *http.Request) {
-	current_edit_id := -1
-	if cookie, err := req.Cookie("last-edit"); err == nil {
-		current_edit_id, _ = strconv.Atoi(cookie.Value)
-	}
-	defer ElapsedPrint("Show status", time.Now())
-	out.Header().Set("Content-Type", "text/html; charset=utf-8")
-	maxStatus := 2100
-	page := &StatusPage{
-		Items: make([]StatusItem, maxStatus),
-	}
-	for i := 0; i < maxStatus; i++ {
-		fillStatusItem(h.store, h.imgPath, i, &page.Items[i])
-		// Zero is a special case that we handle differently in template.
-		if i > 0 {
-			if i%100 == 0 {
-				page.Items[i].Separator = 2
-			} else if i%10 == 0 {
-				page.Items[i].Separator = 1
+	if strings.HasPrefix(req.URL.Path, kApiStatus) {
+		h.apiStatus(out, req)
+	} else {
+		current_edit_id := -1
+		if cookie, err := req.Cookie("last-edit"); err == nil {
+			current_edit_id, _ = strconv.Atoi(cookie.Value)
+		}
+		defer ElapsedPrint("Show status", time.Now())
+		out.Header().Set("Content-Type", "text/html; charset=utf-8")
+		maxStatus := 2100
+		page := &StatusPage{
+			Items: make([]StatusItem, maxStatus),
+		}
+		for i := 0; i < maxStatus; i++ {
+			fillStatusItem(h.store, h.imgPath, i, &page.Items[i])
+			// Zero is a special case that we handle differently in template.
+			if i > 0 {
+				if i%100 == 0 {
+					page.Items[i].Separator = 2
+				} else if i%10 == 0 {
+					page.Items[i].Separator = 1
+				}
 			}
-		}
-		if i == current_edit_id {
-			page.Items[i].Status = page.Items[i].Status + " selstatus"
-		}
+			if i == current_edit_id {
+				page.Items[i].Status = page.Items[i].Status + " selstatus"
+			}
 
+		}
+		h.template.Render(out, "status-table.html", page)
 	}
-	h.template.Render(out, "status-table.html", page)
+}
+
+// Similarly to the Search API, gather the status data and present it in an JSON endpoint.
+func (h *StatusHandler) apiStatus(out http.ResponseWriter, r *http.Request) {
+	rawOffset := r.FormValue("offset")
+	rawLimit := r.FormValue("limit")
+	offset := kApiStatusDefaultOffset
+	limit := kApiStatusDefaultLimit
+	maxStatus := 2100
+
+	//Input validation, restrict inputs from 0 to maxStatus
+	if rawOffset != "" {
+		parsed_offset, err := strconv.Atoi(rawOffset)
+		if err != nil || offset < 0 {
+			offset = kApiStatusDefaultOffset
+		} else {
+			offset = parsed_offset
+		}
+	}
+	if rawLimit != "" {
+		parsed_limit, err := strconv.Atoi(rawLimit)
+		if err != nil || limit < 0 {
+			limit = kApiStatusDefaultLimit
+		} else {
+			limit = parsed_limit
+		}
+	}
+	if offset + limit > maxStatus {
+		offset, limit = 0, maxStatus
+	}
+
+	out.Header().Set("Cache-Control", "max-age=10")
+	out.Header().Set("Content-Type", "application/json")
+
+	page := &StatusPage{
+		Items: make([]StatusItem, limit),
+	}
+
+	for i := offset; i < offset + limit; i++ {
+		fillStatusItem(h.store, h.imgPath, i, &page.Items[i - offset])
+	}
+
+	jsonResult := &JsonApiStatusResult{
+		Directlink: encodeUriComponent(fmt.Sprintf("/status?offset=%d&limit=%d", offset, limit)),
+		Offset:     offset,
+		Limit:      limit,
+		Items:      make([]JsonStatus, limit),
+	}
+
+	for i := 0; i < limit; i++ {
+		jsonResult.Items[i].StatusItem = page.Items[i]
+	}
+
+	json, _ := json.MarshalIndent(jsonResult, "", "  ")
+	out.Write(json)
 }

--- a/stuff/status-handler.go
+++ b/stuff/status-handler.go
@@ -144,7 +144,7 @@ func (h *StatusHandler) apiStatus(out http.ResponseWriter, r *http.Request) {
 	//Input validation, restrict inputs from 0 to maxStatus
 	if rawOffset != "" {
 		parsed_offset, err := strconv.Atoi(rawOffset)
-		if err != nil || offset < 0 {
+		if err != nil || parsed_offset < 0 {
 			offset = kApiStatusDefaultOffset
 		} else {
 			offset = parsed_offset
@@ -152,7 +152,7 @@ func (h *StatusHandler) apiStatus(out http.ResponseWriter, r *http.Request) {
 	}
 	if rawLimit != "" {
 		parsed_limit, err := strconv.Atoi(rawLimit)
-		if err != nil || limit < 0 {
+		if err != nil || parsed_limit < 0 {
 			limit = kApiStatusDefaultLimit
 		} else {
 			limit = parsed_limit


### PR DESCRIPTION
I added APIs that serve as endpoint equivalents for the status page and the read-only page mode. These may be useful for non-browser clients.

I adhered to the coding style as much as possible, and took care of out-of-bound cases by validating the input and setting them to default values if needed instead of returning error 400 for a bad request. I chose to do it this way because I realize a 404 error is done similarity for images. The user sees a placeholder image instead of a broken image icon for items that don't exist.