### PR TITLE
Update build and release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,59 +1,42 @@
 ---
 version: 2.1
 
+executors:
+  golang:
+    docker:
+    - image: circleci/golang:1.14
+
 jobs:
   build:
-    docker:
-    - image: circleci/golang:1.11
+    executor: golang
 
     steps:
+    - add_ssh_keys
     - checkout
-    - run: sudo apt-get -y install file
+    - run: echo $PATH
     - run: go mod download
-    - run: mkdir -v build
+    - run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=/home/circleci/.local/bin sh
     - run: make -C stuff style
-    - run: make -C stuff stuff
     - run: make -C stuff test
-    - run: mv -v stuff/stuff build/stuff-amd64
-    - run: GOARCH=arm GOARM=5 make -C stuff stuff
-    - run: mv -v stuff/stuff build/stuff-armv5
-    - run: file build/*
+    - run: cd stuff && goreleaser release --skip-publish --snapshot
     - persist_to_workspace:
         root: .
         paths:
-        - build
+        - stuff/dist
     - store_artifacts:
-        path: build
+        path: stuff/dist
 
   release:
-    docker:
-    - image: circleci/golang:1.11
+    executor: golang
 
     steps:
+    - add_ssh_keys
     - checkout
-    - run: sudo apt-get update
-    - run: sudo apt-get -y install fakeroot
-    - run: mkdir -v -p ${HOME}/bin
-    - run: curl -L 'https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2' | tar xvjf - --strip-components 3 -C ${HOME}/bin
+    - run: go mod download
+    - run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=/home/circleci/.local/bin sh
     - attach_workspace:
         at: .
-    - run: mkdir "stuff-org-${CIRCLE_TAG}"
-    - run: cp -r stuff/static "stuff-org-${CIRCLE_TAG}/static"
-    - run: cp -r stuff/template "stuff-org-${CIRCLE_TAG}/template"
-    - run: cp build/stuff-amd64 "stuff-org-${CIRCLE_TAG}/stuff-org"
-    - run: fakeroot tar -czvf stuff-org-${CIRCLE_TAG}.amd64.tar.gz "stuff-org-${CIRCLE_TAG}"
-    - run: cp build/stuff-armv5 "stuff-org-${CIRCLE_TAG}/stuff-org"
-    - run: fakeroot tar -czvf stuff-org-${CIRCLE_TAG}.armv5.tar.gz "stuff-org-${CIRCLE_TAG}"
-    - run: sha256sum stuff-org-*.tar.gz | tee sha256sums.txt
-    - run: >
-        for file in stuff-org-*.tar.gz sha256sums.txt ; do
-          ${HOME}/bin/github-release upload \
-            --user "${CIRCLE_PROJECT_USERNAME}" \
-            --repo "${CIRCLE_PROJECT_REPONAME}" \
-            --tag "${CIRCLE_TAG}" \
-            --name "${file}" \
-            --file "${file}"
-        done
+    - run: cd stuff && goreleaser release
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+stuff/dist
 stuff/stuff
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
+
+ADD stuff /bin/stuff
+
+EXPOSE     9199
+USER       nobody
+ENTRYPOINT ["/bin/stuff"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+GO        ?= go
+
+.PHONY: update-go-deps
+update-go-deps:
+	@echo ">> updating Go dependencies"
+	@for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
+		$(GO) get $$m; \
+	done
+	$(GO) mod tidy
+

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/hzeller/stuff-org
 
-require github.com/mattn/go-sqlite3 v1.10.0
+go 1.13
+
+require github.com/mattn/go-sqlite3 v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
-github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
-github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/mattn/go-sqlite3 v1.14.0 h1:mLyGNKR8+Vv9CAU7PphKa2hkEqxxhn8i32J6FPj1/QA=
+github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/stuff/.goreleaser.yml
+++ b/stuff/.goreleaser.yml
@@ -1,0 +1,42 @@
+project_name: stuff-org
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+builds:
+- binary: stuff
+  goarch:
+  - amd64
+  - arm
+  - arm64
+  goarm:
+  - 6
+  - 7
+  goos:
+  - darwin
+  - freebsd
+  - linux
+  - windows
+archives:
+  - files:
+    - static/**/*
+    - template/**/*
+    format_overrides:
+    - goos: windows
+      format: zip
+    wrap_in_directory: true
+checksum:
+  name_template: 'checksums.txt'
+# TODO: Setup Docker in CircleCI.
+# dockers:
+# - image_templates:
+#   - "{{ .Env.CI_REGISTRY_IMAGE }}:latest"
+#   - "{{ .Env.CI_REGISTRY_IMAGE }}:{{ .Tag }}"
+snapshot:
+  name_template: "{{ .Tag }}-{{ .ShortCommit }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
* Update to Go 1.14.
* Add Go module updater make target.
* Switch from manual build to goreleaser.
* Bump go modules.

Signed-off-by: Ben Kochie <superq@gmail.com>