### PR TITLE
Don't persist build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ jobs:
     - run: make -C stuff style
     - run: make -C stuff test
     - run: cd stuff && goreleaser release --skip-publish --snapshot
-    - persist_to_workspace:
-        root: .
-        paths:
-        - stuff/dist
     - store_artifacts:
         path: stuff/dist
 
@@ -34,8 +30,6 @@ jobs:
     - checkout
     - run: go mod download
     - run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=/home/circleci/.local/bin sh
-    - attach_workspace:
-        at: .
     - run: cd stuff && goreleaser release
 
 workflows:


### PR DESCRIPTION
Don't persist build artifacts between build and release. It confuses
goreleaser.

Signed-off-by: Ben Kochie <superq@gmail.com>