### PR TITLE
Added similarity search operator.

### DIFF
--- a/stuff/dbbackend.go
+++ b/stuff/dbbackend.go
@@ -285,6 +285,6 @@ func (d *DBBackend) MatchingEquivSetForComponent(id int) []*Component {
 	return result
 }
 
-func (d *DBBackend) Search(search_term string) []*Component {
+func (d *DBBackend) Search(search_term string) *SearchResult {
 	return d.fts.Search(search_term)
 }

--- a/stuff/main.go
+++ b/stuff/main.go
@@ -33,6 +33,13 @@ type Component struct {
 // Modify a user pointer. Returns 'true' if the changes should be commited.
 type ModifyFun func(comp *Component) bool
 
+// SearchResult holds metadata about the search.
+type SearchResult struct {
+	OrignialQuery  string
+	RewrittenQuery string
+	Results        []*Component
+}
+
 // Interface to our storage backend.
 type StuffStore interface {
 	// Find a component by its ID. Returns nil if it does not exist. Don't
@@ -61,7 +68,7 @@ type StuffStore interface {
 
 	// Given a search term, returns all the components that match, ordered
 	// by some internal scoring system. Don't modify the returned objects!
-	Search(search_term string) []*Component
+	Search(search_term string) *SearchResult
 
 	// Iterate through all elements.
 	IterateAll(func(comp *Component) bool)

--- a/stuff/template/form-template.html
+++ b/stuff/template/form-template.html
@@ -327,6 +327,10 @@
           <tr><td colspan="6">&lt;-[PgUp]</td>
             <td align="right" colspan="6">[PgDn]-&gt;</td>
         </table>
+
+        <hr />
+
+        <div><a href="/search#like:{{.Id}}">Search for more like this</a></div>
       </td>
           </tr>
     </table>


### PR DESCRIPTION
This PR adds the ability to enter "like" queries and a shortcut on the component detail page to find similar components.

I tried to keep consistency with existing code where possible rather than refactoring for a huge diff. I did pull out regex compilations to use [`MustCompile`](https://golang.org/pkg/regexp/#MustCompile) for initialization safety.